### PR TITLE
Handle case where parentId field does not exist

### DIFF
--- a/src/arrayToTree.spec.ts
+++ b/src/arrayToTree.spec.ts
@@ -97,6 +97,31 @@ describe('arrayToTree', () => {
     ])
   })
 
+  it('should work with nested objects with dataField set to null and some parentIds not existing', () => {
+    expect(arrayToTree(
+      ([
+        { id: '4', custom: 'abc' },
+        { id: '31', parentId: '4', custom: '12' },
+        { id: '1941', parentId: '418', custom: 'de' },
+        { id: '1', parentId: '418', custom: 'ZZZz' },
+        { id: '418', custom: 'ü' },
+      ]),
+      { id: 'id', parentId: 'parentId', dataField: null },
+    )).to.deep.equal([
+      {
+        id: '4', custom: 'abc', children: [
+          { id: '31', parentId: '4', custom: '12', children: [] },
+        ],
+      },
+      {
+        id: '418', custom: 'ü', children: [
+          { id: '1941', parentId: '418', custom: 'de', children: [] },
+          { id: '1', parentId: '418', custom: 'ZZZz', children: [] },
+        ],
+      },
+    ])
+  })
+
   it('should work with nested objects and custom keys with dataField set to null', () => {
     expect(arrayToTree(
       ([

--- a/src/arrayToTree.ts
+++ b/src/arrayToTree.ts
@@ -58,7 +58,7 @@ export function arrayToTree (items: Item[], config: Partial<Config> = {}): TreeI
 
     const TreeItem = lookup[itemId]
 
-    if (parentId === null) {
+    if (!parentId) {
       // is a root item
       rootItems.push(TreeItem)
     } else {


### PR DESCRIPTION
I think changing the `parentId` comparison here to include undefined will handle cases where the source data doesn't have the field present.

My data model for this entity is an interface with parentId defined like `parentId?: string`.  I can either go through and make sure I check for undefined, and null them all out in my service layer, but patching this lib felt like a more holistic solution.